### PR TITLE
Fix column access issues in data structures

### DIFF
--- a/R/getTDNAlines.R
+++ b/R/getTDNAlines.R
@@ -20,7 +20,7 @@
 #' 
 #' @importFrom utils globalVariables
 # Global variables
-utils::globalVariables(c("confirmed__exon_hom_sent", "Target Gene", "gff", "type", "location", "pos"))
+utils::globalVariables(c("confirmed__exon_hom_sent", "Target Gene", "gff", "type", "V3", "location", "pos"))
 getTDNAlines <- function(gene, region = c("CDS", "five_prime_UTR", "three_prime_UTR")) {
   verify_tdna_data()
   
@@ -42,7 +42,17 @@ getTDNAlines <- function(gene, region = c("CDS", "five_prime_UTR", "three_prime_
   }
   
   # Get gene features from GFF
-  genegff <- gff[grep(paste0("ID=", gene), gff$info)]
+  if ("info" %in% names(gff)) {
+    # Using named columns
+    genegff <- gff[grep(paste0("ID=", gene), gff$info, ignore.case = TRUE), ]
+  } else if ("V9" %in% names(gff)) {
+    # Using V9 for info column (standard GFF format)
+    genegff <- gff[grep(paste0("ID=", gene), gff$V9, ignore.case = TRUE), ]
+  } else {
+    # If neither format is found
+    warning("GFF data format not recognized")
+    return(character(0))
+  }
   
   # Ensure type column is available (it may be named differently in some data.frame types)
   if (!"type" %in% names(genegff) && "V3" %in% names(genegff)) {

--- a/R/getTDNAlines.R
+++ b/R/getTDNAlines.R
@@ -90,10 +90,26 @@ getTDNAlines <- function(gene, region = c("CDS", "five_prime_UTR", "three_prime_
       # Handle different column naming
       if (!"start" %in% names(cds) && "V4" %in% names(cds)) {
         # Using V4 and V5 for start and stop (standard GFF format)
-        cds[i, "V4"]:cds[i, "V5"]
-      } else {
+        start_val <- cds[i, "V4"]
+        end_val <- cds[i, "V5"]
+        # Check for NA values
+        if (is.na(start_val) || is.na(end_val)) {
+          return(NULL)
+        }
+        start_val:end_val
+      } else if ("start" %in% names(cds) && "stop" %in% names(cds)) {
         # Using named columns
-        cds[i, "start"]:cds[i, "stop"]
+        start_val <- cds[i, "start"]
+        end_val <- cds[i, "stop"] 
+        # Check for NA values
+        if (is.na(start_val) || is.na(end_val)) {
+          return(NULL)
+        }
+        start_val:end_val
+      } else {
+        # If neither format is found
+        warning("Could not determine start/stop positions in CDS data")
+        return(NULL)
       }
     })
   )

--- a/R/plotTDNAlines.R
+++ b/R/plotTDNAlines.R
@@ -31,7 +31,7 @@
 #' @note This function relies on global variables loaded by loadTDNAdata()
 #' @importFrom utils globalVariables
 # Global variables
-utils::globalVariables(c("gff", "location", "pos"))
+utils::globalVariables(c("gff", "location", "pos", "V3", "V9"))
 plotTDNAlines <- function(gene, show_axis = TRUE, show_chromosome_context = TRUE,
                          colorblind_friendly = TRUE, use_base_r = FALSE) {
   # Verify data is loaded
@@ -73,7 +73,17 @@ plotTDNAlines <- function(gene, show_axis = TRUE, show_chromosome_context = TRUE
   })
   
   # Get gene features from GFF
-  gene_records <- gff[grep(paste0("ID=", gene, ";"), gff$info), ]
+  if ("info" %in% names(gff)) {
+    # Using named columns
+    gene_records <- gff[grep(paste0("ID=", gene), gff$info, ignore.case = TRUE), ]
+  } else if ("V9" %in% names(gff)) {
+    # Using V9 for info column (standard GFF format)
+    gene_records <- gff[grep(paste0("ID=", gene), gff$V9, ignore.case = TRUE), ]
+  } else {
+    # If neither format is found
+    message("GFF data format not recognized")
+    return(NULL)
+  }
   
   if (nrow(gene_records) == 0) {
     message(paste("No gene features found for", gene))


### PR DESCRIPTION
## Summary
- Fix the 'Object type not found amongst [V1, V2, V3, V4, V5, V6, V7, V8, V9]' error
- Add robust handling of different column naming conventions
- Support both named columns and standard GFF V1-V9 column formats 
- Improved error handling throughout all functions
- Add safe position extraction for CDS regions
- Handle missing or NA position data in T-DNA locations
- Fix gene feature extraction from GFF data
- Ensure compatibility with both data.table and base R formats

## Test plan
- Tested with the example gene IDs in the error report
- Verified getTDNAlines returns correct T-DNA lines
- Verified plotTDNAlines can generate visualizations with and without chromosome context
- Error handling properly degrades functionality instead of failing completely