### PR TITLE
Fix search button functionality to work with mouse clicks

### DIFF
--- a/web/client/src/components/GeneSearch.tsx
+++ b/web/client/src/components/GeneSearch.tsx
@@ -116,6 +116,7 @@ const GeneSearch: React.FC<GeneSearchProps> = ({ onGeneSelect, initialGeneId }) 
           variant="contained" 
           color="primary"
           disabled={loading || (!selectedGene && !searchTerm.match(/^AT[1-5]G\d+$/i))}
+          onClick={handleSubmit}
         >
           Search T-DNA Lines
         </Button>


### PR DESCRIPTION
## Summary
- Added onClick handler to the 'Search T-DNA Lines' button in GeneSearch component
- Previously the search only worked when pressing Enter but not when clicking the button
- This makes the UI more intuitive for users who expect clicking a button to trigger the search

## Test plan
1. Run the application locally
2. Enter a valid gene ID (e.g., AT1G25320) in the search field
3. Click the 'Search T-DNA Lines' button (without pressing Enter)
4. Verify that the search is performed and results are displayed
