### PR TITLE
Fix search button functionality and update terminology

### DIFF
--- a/web/client/src/components/GeneSearch.tsx
+++ b/web/client/src/components/GeneSearch.tsx
@@ -57,15 +57,27 @@ const GeneSearch: React.FC<GeneSearchProps> = ({ onGeneSelect, initialGeneId }) 
     };
   }, [searchTerm]);
 
-  // Handle form submission
-  const handleSubmit = (event: React.FormEvent) => {
-    event.preventDefault();
+  // Function to perform the search
+  const performSearch = () => {
+    // Don't do anything if button would be disabled
+    if (loading || (!selectedGene && !searchTerm.match(/^AT[1-5]G\d+$/i))) {
+      return;
+    }
+    
+    console.log("Search performed", { selectedGene, searchTerm });
+    
     if (selectedGene) {
       onGeneSelect(selectedGene.gene_id);
     } else if (searchTerm && searchTerm.match(/^AT[1-5]G\d+$/i)) {
       // If input matches Arabidopsis gene ID pattern, treat as a direct gene ID search
       onGeneSelect(searchTerm.toUpperCase());
     }
+  };
+  
+  // Handle form submission
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    performSearch();
   };
 
   return (
@@ -109,14 +121,23 @@ const GeneSearch: React.FC<GeneSearchProps> = ({ onGeneSelect, initialGeneId }) 
           onInputChange={(_, newInputValue) => {
             setSearchTerm(newInputValue);
           }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              performSearch();
+            }
+          }}
         />
         
         <Button 
-          type="submit" 
+          type="button" 
           variant="contained" 
           color="primary"
           disabled={loading || (!selectedGene && !searchTerm.match(/^AT[1-5]G\d+$/i))}
-          onClick={handleSubmit}
+          onClick={(e) => {
+            e.preventDefault(); // Prevent any default behavior
+            performSearch();
+          }}
         >
           Search T-DNA Lines
         </Button>

--- a/web/client/src/components/TDNAResults.tsx
+++ b/web/client/src/components/TDNAResults.tsx
@@ -87,7 +87,7 @@ const TDNAResults: React.FC<TDNAResultsProps> = ({ geneId, tdnaLines, isLoading 
           T-DNA Lines for {geneId}
         </Typography>
         <Typography variant="body1" align="center" sx={{ my: 4 }}>
-          No T-DNA insertion lines found for this gene
+          No T-DNA insertion lines found for this locus
         </Typography>
       </Paper>
     );

--- a/web/client/src/pages/HomePage.tsx
+++ b/web/client/src/pages/HomePage.tsx
@@ -58,6 +58,7 @@ const HomePage: React.FC = () => {
   
   // Handle gene selection
   const handleGeneSelect = (geneId: string) => {
+    console.log("Gene selected in HomePage:", geneId);
     setSelectedGeneId(geneId);
   };
   


### PR DESCRIPTION
## Summary
- Fixed search button functionality to properly handle clicks and enter key presses
- Changed terminology from 'gene' to 'locus' in the 'No T-DNA insertion lines found' message
- Added improved debugging to help track down any future issues

## The Search Button Fix
The previous fix wasn't handling events correctly. This solution:
- Extracts search logic into a separate function that's called from multiple places
- Properly prevents default form behavior
- Adds an explicit onKeyDown handler to handle Enter key properly 
- Makes the button always work as type='button' (not 'submit')

## Testing
1. Type a valid gene ID (e.g., AT1G25320) and click the search button
2. Type a valid gene ID and press Enter
3. Select a gene from the dropdown and click the search button
4. Verify the 'No T-DNA insertion lines found for this locus' message for genes without T-DNA lines