### PR TITLE
Add Docker deployment files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# Ignore Git files
+.git
+.gitignore
+# Node modules
+**/node_modules
+# Next build output
+**/.next
+# Test files
+tests
+# R generated files
+*.Rproj

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Use Node.js 18 for building dependencies
+FROM node:18-alpine AS deps
+WORKDIR /app
+# Install dependencies for the Next.js web application
+COPY Web/package.json ./
+RUN npm install
+
+# Build the Next.js application
+FROM node:18-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY Web ./
+COPY inst ./inst
+RUN npm run build && npm prune --production
+
+# Runtime image
+FROM node:18-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/next.config.js ./next.config.js
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/inst ./inst
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/Web/README.md
+++ b/Web/README.md
@@ -12,3 +12,18 @@ npm run dev
 ```
 
 The app expects the R package data files found in `../inst/extdata` and uses them directly via the server API.
+
+## Deployment
+
+The repository contains a `Dockerfile` so the web application can be deployed on
+[Railway](https://railway.app/) or any container platform.  Railway will detect
+the `Dockerfile` and build the image automatically.
+
+To test the container locally run:
+
+```bash
+docker build -t tdna-web .
+docker run -p 3000:3000 tdna-web
+```
+
+The application will start on port `3000`.


### PR DESCRIPTION
## Summary
- create Dockerfile for building the web app
- ignore build artifacts with `.dockerignore`
- document Docker deployment in `Web/README.md`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a9648fefc8327ab7350f923df32fa